### PR TITLE
CREATE : 카카오로그인 구현

### DIFF
--- a/core/utils.py
+++ b/core/utils.py
@@ -1,0 +1,53 @@
+import json
+import re
+import jwt
+import requests
+
+from django.http            import JsonResponse
+from django.views           import View
+
+from wescanner.settings import SECRET_KEY,ALGORITHM
+from users.models       import User
+
+# kakao.py
+class KakaoAPI:
+    def __init__(self, access_token):
+        self.access_token = access_token
+        self.user_url     = "https://kapi.kakao.com/v2/user/me"
+
+    def get_kakao_user_information(self):
+        headers = {"Authorization": f'bearer{self.access_token}'}
+        response = requests.get(self.user_url, headers=headers, timeout=3).json()
+
+        if response.get('code') == -1:
+                return JsonResponse({'message' : 'KAKAO_ERROR'}, status=400)
+
+        if response.get('code') == -401:
+            return JsonResponse({'message' : 'INVALID_TOKEN'}, status=401)
+        
+        if 'email' not in response['kakao_account']:
+            return JsonResponse({'message': 'NONE_EMAIL'}, status = 405)
+            
+        return response
+
+def login_decorator(func):
+    def wrapper(self, request, *args, **kwargs):
+        try:
+            assess_token = request.headers.get('Authorization',None) 
+            payload      = jwt.decode(assess_token, SECRET_KEY, ALGORITHM) 
+            user         = User.objects.get(id=payload['user_id']) 
+            request.user = user
+            return func(self, request, *args, **kwargs)
+
+        except jwt.exceptions.InvalidSignatureError: 
+            return JsonResponse({'message': 'INVALID_SIGNATURE_ERROR'}, status=401)
+
+        except jwt.exceptions.DecodeError:
+            return JsonResponse({'message': 'DECODE_ERROR' }, status=401)
+
+        except User.DoesNotExist:
+            return JsonResponse({'message': 'USER_DOES_NOT_EXIST_ERROR'}, status=401)
+
+        except jwt.exceptions.ExpiredSignatureError:
+            return JsonResponse({"message": "EXPIRED_TOKEN"}, status=401)
+    return wrapper   

--- a/requirments.txt
+++ b/requirments.txt
@@ -5,3 +5,4 @@ mysqlclient==2.1.1
 bcrypt==3.2.2
 jwt==1.3.1
 PyJWT==2.4.0
+requests==2.28.1

--- a/users/migrations/0001_initial.py
+++ b/users/migrations/0001_initial.py
@@ -34,7 +34,7 @@ class Migration(migrations.Migration):
                 ('created_at', models.DateTimeField(auto_now_add=True)),
                 ('updated_at', models.DateTimeField(auto_now=True)),
                 ('email', models.CharField(max_length=45, unique=True)),
-                ('kakao_id', models.IntegerField(unique=True)),
+                ('kakao_id', models.BigIntegerField(null=True, unique=True)),
             ],
             options={
                 'db_table': 'users',

--- a/users/models.py
+++ b/users/models.py
@@ -5,7 +5,7 @@ from core.models import TimeStampModel
 # Create your models here.
 class User(TimeStampModel):   
     email    = models.CharField(max_length = 45,unique = True)
-    kakao_id = models.IntegerField(unique = True, null=True)
+    kakao_id = models.BigIntegerField(unique = True, null=True)
     class Meta:
         db_table = 'users'
 

--- a/users/tests.py
+++ b/users/tests.py
@@ -1,3 +1,76 @@
-from django.test import TestCase
+import jwt
 
-# Create your tests here.
+from unittest.mock import patch, MagicMock
+from django.test import Client, TestCase
+from django.conf import settings
+
+from users.models import User
+
+class test_KakaoLogin(TestCase):
+    def setUp(self):
+        User.objects.create(
+            id       = 5,
+            kakao_id = '2323232',
+            email    = 'q1w2e3r4@naver.com'
+        )
+
+    def tearDown(self):
+        User.objects.all().delete()
+
+    @patch('core.utils.requests')
+    def test_success_kakao_login(self, mocked_requests):
+        client = Client()
+
+        class MockedResponse:
+            def json(self):
+                return {
+                    'id'            : 2323232, 
+                    'connected_at'  : '2022-07-06T08:16:22Z', 
+                    'kakao_account' : {
+                        'has_email'             : True, 
+                        'email_needs_agreement' : False, 
+                        'is_email_valid'        : True, 
+                        'is_email_verified'     : True, 
+                        'email'                 : 'q1w2e3r4@naver.com'
+                        }
+                    }
+
+        mocked_requests.get = MagicMock(return_value = MockedResponse())
+        headers             = {'HTTP_Authorization': '1343434'}
+        response            = client.get('/users/kakao', **headers)
+        access_token        = jwt.encode({'user_id': User.objects.get(id=5).id}, settings.SECRET_KEY, settings.ALGORITHM)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(),{
+            'message'      : 'LOGIN',
+            'access_token' : access_token
+        })
+
+    @patch('core.utils.requests')
+    def test_success_kakao_create(self, mocked_requests):
+        client = Client()
+
+        class MockedResponse:
+            def json(self):
+                return {
+                    'id'            : 2342342, 
+                    'connected_at'  : '2022-07-06T08:16:22Z', 
+                    'kakao_account' : {
+                        'has_email'             : True, 
+                        'email_needs_agreement' : False, 
+                        'is_email_valid'        : True, 
+                        'is_email_verified'     : True, 
+                        'email'                 : 'a12s2d34f4@naver.com'
+                        }
+                    }
+
+        mocked_requests.get = MagicMock(return_value = MockedResponse())
+        headers             = {'HTTP_Authorization': '3434346'}
+        response            = client.get('/users/kakao', **headers)
+        access_token        = jwt.encode({'user_id': 6}, settings.SECRET_KEY, settings.ALGORITHM)
+
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(
+            response.json(),{
+                'message'      : 'CREATE_USER',
+                'access_token' : access_token 
+        })

--- a/users/urls.py
+++ b/users/urls.py
@@ -1,8 +1,8 @@
 from django.urls import path
 
-from .views import EmailLoginView
+from .views import EmailLoginView, KakaoLoginView
 
 urlpatterns = [
-    path('/email',EmailLoginView.as_view())
+    path('/email',EmailLoginView.as_view()),
+    path('/kakao',KakaoLoginView.as_view())
 ]
-

--- a/users/views.py
+++ b/users/views.py
@@ -1,13 +1,16 @@
 import json
+from os import access
 import re
 import jwt
+import requests
 
 from django.http            import JsonResponse
 from django.views           import View
 from django.core.exceptions import ValidationError
 
 from wescanner.settings import SECRET_KEY,ALGORITHM
-from users.models   import User
+from users.models       import User
+from core.utils         import KakaoAPI
 
 class EmailLoginView(View):
     def post(self,request):
@@ -32,4 +35,36 @@ class EmailLoginView(View):
             return JsonResponse({"access_token" : token},status=200)
 
         except KeyError: 
-            return JsonResponse({"message":"KEY_ERROR"},status=400)
+            return JsonResponse({"message": "KEY_ERROR"}, status=400)
+
+
+class KakaoLoginView(View):
+    def get(self, request):
+        try:
+            access_token = request.headers['Authorization']
+            kakao_api    = KakaoAPI(access_token)
+            response     = kakao_api.get_kakao_user_information()
+            
+            kakao_id = response['id']
+
+            user, is_created = User.objects.get_or_create(
+                kakao_id = kakao_id
+            )
+            
+            status  = 201 if is_created else 200
+            message = 'CREATE_USER' if is_created else 'LOGIN'
+            
+            access_token = jwt.encode({'user_id': user.id}, SECRET_KEY, ALGORITHM)
+            
+            message = {
+                'message'      : message,
+                'access_token' : access_token
+                }
+            
+            return JsonResponse(message, status=status)            
+        
+        except User.DoesNotExist:
+            return JsonResponse({'message': 'INVALID_USER'}, status=404)
+        
+        except KeyError:
+            return JsonResponse({'message': 'KEY_ERROR'}, status=400)

--- a/wescanner/settings.py
+++ b/wescanner/settings.py
@@ -12,7 +12,7 @@ https://docs.djangoproject.com/en/4.0/ref/settings/
 
 from pathlib    import Path
 
-from my_settings import SECRET_KEY,DATABASES, ALGORITHM
+from my_settings import SECRET_KEY,DATABASES, ALGORITHM, KAKAOAPI_KEY
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
@@ -24,8 +24,9 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 # SECURITY WARNING: keep the secret key used in production secret!
 SECRET_KEY = SECRET_KEY
 
-ALGORITHM = ALGORITHM 
+ALGORITHM = ALGORITHM
 
+KAKAOAPI_KEY = KAKAOAPI_KEY
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [ ] 기능 추가
- [x] 리뷰 반영
- [x] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
- 카카오 소셜로그인

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
프론트에서 토큰을 받아 해당 토큰을 이용해서 카카오 계정의 PK(kakao_id) 받아오기

이미 웹페이지에 로그인을 했던 유저라면 `GET`
처음 로그인을 하는 유저라면 `CREATE` 을 하여 users table 등록




<br />

## :: 성장 포인트 (해당 기능을 구현하며 고민했던 사항이나 새로 알게된 부분, 어려웠던 점 등을 작성합니다.)
-   프론트에서 인가코드를 이용하여 받은 토큰으로 카카오 계정을 받아오는 기능을 구현해보았는데 코드를 구현하는 것보다 POSTMAN을 이용하여 테스트 해보는게 어려웠다.

### E2E Tests
동일 IP상으로 통신 성공
프론트 단에서 kakao_Token을 넘겨주면 kakao_API를 이용하여 유효 계정 확인 후 프로젝트 API서버에서 이용할 access_Token을 프론트 단에게 반환

### Intergration Tests
- POSTMAN을 이용하여 테스트
<img width="1392" alt="스크린샷 2022-07-07 오후 3 54 02" src="https://user-images.githubusercontent.com/95075455/177710690-4463d570-e218-4398-b824-d7b56237431b.png">

### Unit Tests 
Mock데이터 생성하여 MockResponse로 확인

<br />


